### PR TITLE
Feature/iat 2476 - Updated source directory configuration

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -17,7 +17,7 @@ server:
 
 security:
   basic:
-    enabled: "${SECURITY_ENABLED:true}"
+    enabled: "false"
   user:
     name: "admin"
     password: "admin"
@@ -75,14 +75,15 @@ logging:
           common: "info"
 
 item-import:
-  dryRun: false
+  dryRun: true
   environment: "LOCAL"
   systemUsername: "item-import@smarterbalanced.org"
   systemFullname: "Item Import"
   deleteIfExists: true
   localBaseDir: "${HOME}/ItemImportTemp"
-  itemSourceDir: "${HOME}/ItemImportStaging/items"
-  stimuliSourceDir: "${HOME}/ItemImportStaging/stimuli"
+  itemSourceDir: "${HOME}/ItemImportStaging/sa"
+  stimuliSourceDir: "${HOME}/ItemImportStaging/stim"
+  wordlistSourceDir: "${HOME}/ItemImportStaging/wit"
   importIdFile: "import-ids.txt"
   numberOfThreads: 4
   publishReportEnabled: true

--- a/application.yml
+++ b/application.yml
@@ -17,7 +17,7 @@ server:
 
 security:
   basic:
-    enabled: "false"
+    enabled: "${SECURITY_ENABLED:true}"
   user:
     name: "admin"
     password: "admin"

--- a/application.yml
+++ b/application.yml
@@ -24,7 +24,7 @@ security:
 
 spring:
   session:
-    enabled: "${SESSION_CLUSTER_ENABLED:true}"
+    enabled: "false"
   datasource:
     url: "jdbc:postgresql://localhost:5432/iat"
     username: "${DB_USER}"

--- a/import-ids.txt
+++ b/import-ids.txt
@@ -1,2 +1,1 @@
-Item-200-22777,Released
-Item-200-21,Rejected
+Item-200-52520,Released

--- a/import-ids.txt
+++ b/import-ids.txt
@@ -1,2 +1,2 @@
 Item-200-22777,Released
-Item-200-21,Released
+Item-200-21,Rejected

--- a/src/main/java/org/opentestsystem/ap/itemimport/config/AppProps.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/config/AppProps.java
@@ -58,6 +58,11 @@ public class AppProps {
     private String stimuliSourceDir = "";
 
     /**
+     * Required. Directory where wordlist files will be read
+     */
+    private String wordlistSourceDir = "";
+
+    /**
      * Required. Text file that contains a list of item ids to be imported
      */
     private String importIdFile = "";

--- a/src/main/java/org/opentestsystem/ap/itemimport/handler/ItemImportHandler.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/handler/ItemImportHandler.java
@@ -97,7 +97,7 @@ public class ItemImportHandler {
                         final SmarterAppMetadata itemMetadata = this.appAssembler.getSaaifAssembler()
                                 .getMetadataAssembler().readXmlFromFile(metaFile.toPath());
 
-                        final ItemProps itemProps = ImportHandlerUtil.loadItemProps(itemRelease);
+                        final ItemProps itemProps = ImportHandlerUtil.loadItemProps(itemDirName, itemRelease);
 
                         itemProps.setImportWorkflowStatus(itemWorkflowStatus);
 
@@ -220,6 +220,8 @@ public class ItemImportHandler {
                 sourceItemFullPath,
                 localRepositoryPath);
 
+        String commitMessage = ImportHandlerUtil.getItemCommitMessage(itemRelease, metadata);
+
         if (!appProps.isDryRun()) {
             itemManager.createItem(
                     itemBankProperties.getSystemUser(),
@@ -231,9 +233,11 @@ public class ItemImportHandler {
 
             itemBankSyncManager.syncAttachmentsToDataStore(itemProps.getImportItemId(), BRANCH_MASTER, localRepositoryPath);
 
-            String commitMessage = ImportHandlerUtil.getItemCommitMessage(itemRelease, metadata);
+
             itemManager.commitItem(itemBankProperties.getSystemUser(), item, commitMessage);
         }
+
+        importResult.setCommitMessage(commitMessage);
 
         importResult.setStatus(IatImportConstants.STATUS_SUCCESS);
 

--- a/src/main/java/org/opentestsystem/ap/itemimport/model/ItemProps.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/model/ItemProps.java
@@ -17,6 +17,8 @@ public class ItemProps {
     private String tutorialId;
 
     //Calculated values used during import
+    private String wordListDirName;
+
     private String wordlistFullId;
 
     private String importItemId;

--- a/src/main/java/org/opentestsystem/ap/itemimport/model/report/ImportResult.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/model/report/ImportResult.java
@@ -17,6 +17,8 @@ public class ImportResult {
 
     private String itemType = "";
 
+    private String commitMessage = "";
+
     private String status = IatImportConstants.STATUS_SUCCESS;
 
     private List<String> errorMessages = new ArrayList<>();

--- a/src/main/java/org/opentestsystem/ap/itemimport/repository/ReportRepository.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/repository/ReportRepository.java
@@ -22,7 +22,7 @@ import static freemarker.template.Configuration.VERSION_2_3_25;
 @Slf4j
 @Component
 public class ReportRepository {
-    private static final String REPORT_FILE_NAME_PATTERN = "import-%1$tF-%1$tT.txt";
+    private static final String REPORT_FILE_NAME_PATTERN = "import-%1$tF-%1$tT.log";
 
     private static final String REPORT_TEMPLATE = "import-report.ftl";
 

--- a/src/main/java/org/opentestsystem/ap/itemimport/util/ImportFileUtil.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/util/ImportFileUtil.java
@@ -348,8 +348,7 @@ public class ImportFileUtil {
                                     appProps.getItemSourceDir(),
                                     itemProps.getWordlistFullId().replace("item", "Item"));
         File wordDir = new File(wordListDirectory);
-        if (wordDir.exists() && wordDir.isDirectory()
-                && wordDir.getCanonicalPath().equals(wordListDirectory)) {
+        if (wordDir.exists() && wordDir.isDirectory()) {
             return wordListDirectory;
         } else {
             // Attempt to find Wordlist source directory named as the value in the ItemRelease of the imported item
@@ -357,12 +356,25 @@ public class ImportFileUtil {
                     appProps.getItemSourceDir(),
                     itemProps.getWordlistFullId());
             wordDir = new File(wordListDirectory);
-            if (wordDir.exists() && wordDir.isDirectory()
-                    && wordDir.getCanonicalPath().equals(wordListDirectory)) {
+            if (wordDir.exists() && wordDir.isDirectory()) {
                 return wordListDirectory;
             } else {
-                throw new Exception(String.format("Unable to find Wordlist directory: %s", wordListDirectory));
+                throw new Exception(String.format("Unable to find Wordlist directory: %s, %s, %s, %s, %s, %s",
+                        wordListDirectory,
+                        appProps.getItemSourceDir(),
+                        itemProps.getWordlistFullId(),
+                        wordDir.exists(),
+                        wordDir.isDirectory(),
+                        wordDir.getCanonicalPath()));
             }
+            /*
+            /home/imrt-stage/efs/ItemImportStaging/items/item-200-70499,
+            /home/imrt-stage/efs/ItemImportStaging/items,
+            item-200-70499,
+            false,
+            false,
+            /efs/imrt-stage/ItemImportStaging/items/item-200-70499"
+            */
         }
     }
 

--- a/src/main/java/org/opentestsystem/ap/itemimport/util/ImportFileUtil.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/util/ImportFileUtil.java
@@ -342,39 +342,21 @@ public class ImportFileUtil {
     }
 
     public static String getWordListDirectory(final AppProps appProps,
-                                              final ItemProps itemProps) throws Exception{
-        // Attempt to find Wordlist source directory named with a capital I in "Item"
+                                              final ItemProps itemProps) throws Exception {
         String wordListDirectory = String.format("%s/%s",
-                                    appProps.getItemSourceDir(),
-                                    itemProps.getWordlistFullId().replace("item", "Item"));
+                                    appProps.getWordlistSourceDir(),
+                                    itemProps.getWordListDirName());
         File wordDir = new File(wordListDirectory);
         if (wordDir.exists() && wordDir.isDirectory()) {
             return wordListDirectory;
         } else {
-            // Attempt to find Wordlist source directory named as the value in the ItemRelease of the imported item
-            wordListDirectory = String.format("%s/%s",
+            throw new Exception(String.format("Unable to find Wordlist directory: %s, %s, %s, %s, %s, %s",
+                    wordListDirectory,
                     appProps.getItemSourceDir(),
-                    itemProps.getWordlistFullId());
-            wordDir = new File(wordListDirectory);
-            if (wordDir.exists() && wordDir.isDirectory()) {
-                return wordListDirectory;
-            } else {
-                throw new Exception(String.format("Unable to find Wordlist directory: %s, %s, %s, %s, %s, %s",
-                        wordListDirectory,
-                        appProps.getItemSourceDir(),
-                        itemProps.getWordlistFullId(),
-                        wordDir.exists(),
-                        wordDir.isDirectory(),
-                        wordDir.getCanonicalPath()));
-            }
-            /*
-            /home/imrt-stage/efs/ItemImportStaging/items/item-200-70499,
-            /home/imrt-stage/efs/ItemImportStaging/items,
-            item-200-70499,
-            false,
-            false,
-            /efs/imrt-stage/ItemImportStaging/items/item-200-70499"
-            */
+                    itemProps.getWordlistFullId(),
+                    wordDir.exists(),
+                    wordDir.isDirectory(),
+                    wordDir.getCanonicalPath()));
         }
     }
 

--- a/src/main/java/org/opentestsystem/ap/itemimport/util/ImportHandlerUtil.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/util/ImportHandlerUtil.java
@@ -99,12 +99,6 @@ public class ImportHandlerUtil {
 
                 setWordListValues(itemDirName, release, itemProps);
 
-//                if (itemProps.getItemId().startsWith("Item")) {
-//                    itemProps.setWordListDirName();
-//                }
-//
-//                itemProps.setWordlistFullId(getWordlistFullId(release));
-
                 itemProps.setImportItemId(getImportId(ID_TYPE.ITEM,
                         release.getItem().getId(),
                         release.getItem().getBankkey()));

--- a/src/main/java/org/opentestsystem/ap/itemimport/util/ImportHandlerUtil.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/util/ImportHandlerUtil.java
@@ -77,7 +77,7 @@ public class ImportHandlerUtil {
      * @return
      * @throws Exception
      */
-    public static ItemProps loadItemProps(ItemRelease release) throws Exception {
+    public static ItemProps loadItemProps(String itemDirName, ItemRelease release) throws Exception {
         ItemProps itemProps = new ItemProps();
 
         if (release.getPassage() != null) {
@@ -96,7 +96,14 @@ public class ImportHandlerUtil {
                 }
                 itemProps.setAssociatedPassage(release.getItem().getAssociatedpassage());
                 itemProps.setTutorialId(release.getItem().getTutorial().getId());
-                itemProps.setWordlistFullId(getWordlistFullId(release));
+
+                setWordListValues(itemDirName, release, itemProps);
+
+//                if (itemProps.getItemId().startsWith("Item")) {
+//                    itemProps.setWordListDirName();
+//                }
+//
+//                itemProps.setWordlistFullId(getWordlistFullId(release));
 
                 itemProps.setImportItemId(getImportId(ID_TYPE.ITEM,
                         release.getItem().getId(),
@@ -208,13 +215,21 @@ public class ImportHandlerUtil {
      * @param release
      * @return
      */
-    private static String getWordlistFullId(ItemRelease release) {
+    private static void setWordListValues(String itemDirName,
+                                          ItemRelease release,
+                                          ItemProps itemProps) {
         if (release.getItem().getResourceslist().getResource().size() == 1) {
             String wlId = release.getItem().getResourceslist().getResource().get(0).getId();
             String wlBankKey = release.getItem().getResourceslist().getResource().get(0).getBankkey();
-            return String.format("item-%s-%s", wlBankKey, wlId);
+            itemProps.setWordlistFullId(String.format("item-%s-%s", wlBankKey, wlId));
+
+            String wordListDirName = itemProps.getWordlistFullId();
+            if (itemDirName.startsWith("Item")) {
+                wordListDirName = itemProps.getWordlistFullId().replace("item", "Item");
+            }
+
+            itemProps.setWordListDirName(wordListDirName);
         }
-        return "";
     }
 
     /**

--- a/src/main/resources/report_templates/import-report.ftl
+++ b/src/main/resources/report_templates/import-report.ftl
@@ -10,11 +10,11 @@ Execution Time: ${report.executionTime}
 
 The following items were imported successfully
 --------------------------------------------------
-"its id","tims id","status","item type"
+"its id","tims id","status","item type","commit message"
 <#list report.importResults>
     <#items as result>
         <#if result.status == "SUCCESS">
-"${result.itemId}","${result.importedItemId}","success","${result.itemType}"
+"${result.itemId}","${result.importedItemId}","success","${result.itemType}","${result.commitMessage}"
         </#if>
     </#items>
 </#list>


### PR DESCRIPTION
* Updated source directory configuration to include new "wordlistSourceDir" property:

```
itemSourceDir: "${HOME}/ItemImportStaging/sa"
stimuliSourceDir: "${HOME}/ItemImportStaging/stim"
wordlistSourceDir: "${HOME}/ItemImportStaging/wit"
```

itemSourceDir should be set to a local directory where item files are located
stimuliSourceDir should be set to a local directory where the stimulus files are located
wordlistSourceDir should be set to a local directory where wordlist item files are located

This change will allow the ability separate directories by item type

* Disabled spring sessions
* Changed log extension to .log
* Added the commit message to the log output