### PR TITLE
Fixes for IAT-2485 and IAT-2486

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -79,11 +79,11 @@ item-import:
   environment: "LOCAL"
   systemUsername: "item-import@smarterbalanced.org"
   systemFullname: "Item Import"
-  deleteIfExists: true
+  deleteIfExists: false
   localBaseDir: "${HOME}/ItemImportTemp"
-  itemSourceDir: "${HOME}/ItemImportStaging/sa"
-  stimuliSourceDir: "${HOME}/ItemImportStaging/stim"
-  wordlistSourceDir: "${HOME}/ItemImportStaging/wit"
+  itemSourceDir: "${HOME}/ItemImportSource/prod/items"
+  stimuliSourceDir: "${HOME}/ItemImportSource/prod/stimulus"
+  wordlistSourceDir: "${HOME}/ItemImportSource/prod/items"
   importIdFile: "import-ids.txt"
   numberOfThreads: 4
   publishReportEnabled: true

--- a/import-ids.txt
+++ b/import-ids.txt
@@ -1,1 +1,1 @@
-Item-200-52520,Released
+Item-200-1368,ParkingLot

--- a/src/main/java/org/opentestsystem/ap/itemimport/mapper/IatModelMapper.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/mapper/IatModelMapper.java
@@ -931,6 +931,11 @@ public abstract class IatModelMapper {
         final Document doc = Jsoup.parseBodyFragment(htmlContent);
         doc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
 
+        Elements spans = doc.getElementsByTag("span");
+        spans.forEach(span -> {
+            span.attr("style", "");
+        });
+
         Elements parTags = doc.getElementsByTag("p");
 
         // Expect only one wrapping <p> tag
@@ -1595,7 +1600,7 @@ public abstract class IatModelMapper {
                 break;
             }
             case GlossaryConstants.ListCode.UKRANIAN : {
-                language = "ukranian";
+                language = "ukrainian";
                 break;
             }
             case GlossaryConstants.ListCode.VIETNAMESE : {


### PR DESCRIPTION
* Fixed IAT-2485 by setting span style attribute to "" before processing glossary terms. This allows to split the content with a , to obtain the different dialects
* Fixed IAT-2486 by updated misspelled "ukrainian" language definition