### PR TITLE
iat-2558 Changed directory where import.zip is created

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -81,9 +81,9 @@ item-import:
   systemFullname: "Item Import"
   deleteIfExists: false
   localBaseDir: "${HOME}/ItemImportTemp"
-  stimuliSourceDir: "${HOME}/ItemImportSource/prod/stimulus"
-  wordlistSourceDir: "${HOME}/ItemImportSource/prod/items"
-  itemSourceDir: "${HOME}/ItemImportSource/prod/items"
+  stimuliSourceDir: "${HOME}/ItemImportStaging/stim"
+  wordlistSourceDir: "${HOME}/ItemImportStaging/wit"
+  itemSourceDir: "${HOME}/ItemImportStaging/sa"
   importIdFile: "import-ids.txt"
   numberOfThreads: 4
   publishReportEnabled: true

--- a/import-ids.txt
+++ b/import-ids.txt
@@ -1,1 +1,1 @@
-Item-200-56561,ParkingLot
+Item-200-62497,ParkingLot

--- a/import-ids.txt
+++ b/import-ids.txt
@@ -1,1 +1,1 @@
-Item-200-62497,ParkingLot
+Item-200-83796,ParkingLot

--- a/src/main/java/org/opentestsystem/ap/itemimport/handler/ItemImportHandler.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/handler/ItemImportHandler.java
@@ -24,6 +24,7 @@ import org.opentestsystem.ap.itemimport.util.ImportHandlerUtil;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.opentestsystem.ap.common.model.ItemConstants.BranchNames.BRANCH_MASTER;
@@ -168,7 +169,7 @@ public class ItemImportHandler {
                                        WordlistreleaseType wordListRelease,
                                        String wordlistFullPath,
                                        String sourceItemFullPath,
-                                       ImportResult importResult) {
+                                       ImportResult importResult) throws IOException {
 
         if (itemProps.getItemType().equalsIgnoreCase(HTQ)) {
             itemProps.setItemType(ImportHandlerUtil.getIatHtqType(itemRelease));

--- a/src/main/java/org/opentestsystem/ap/itemimport/handler/ItemImportHandler.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/handler/ItemImportHandler.java
@@ -243,7 +243,7 @@ public class ItemImportHandler {
         successMessage += itemProps.getItemId();
         log.info(successMessage);
 
-        ImportFileUtil.deleteDirectory(localRepositoryPath.toFile());
+        ImportFileUtil.deleteDirectory(localRepositoryPath.toFile().getParentFile());
 
         return importResult;
     }

--- a/src/main/java/org/opentestsystem/ap/itemimport/service/ImportServiceValidator.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/service/ImportServiceValidator.java
@@ -82,13 +82,13 @@ public class ImportServiceValidator {
         props.add("isDryRun: " + appProps.isDryRun());
         props.add("environment: " + appProps.getEnvironment());
         props.add("deleteIfExists: " + appProps.isDeleteIfExists());
-        props.add("importIdFile: " + appProps.getImportIdFile());
         props.add("systemUsername: " + appProps.getSystemUsername());
         props.add("systemFullName: " + appProps.getSystemFullname());
-        props.add("");
-        props.add("itemSourceDir: " + appProps.getItemSourceDir());
         props.add("stimuliSourceDir: " + appProps.getStimuliSourceDir());
         props.add("wordlistSourceDir: " + appProps.getWordlistSourceDir());
+        props.add("");
+        props.add("itemSourceDir: " + appProps.getItemSourceDir());
+        props.add("importIdFile: " + appProps.getImportIdFile());
         props.add("");
         return props;
     }

--- a/src/main/java/org/opentestsystem/ap/itemimport/util/ImportFileUtil.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/util/ImportFileUtil.java
@@ -174,12 +174,9 @@ public class ImportFileUtil {
         }
     }
 
-    public static void copyDirectoryToDirectory(File sourceDirectory, File destinationDirectory) {
-        try {
-            FileUtils.copyDirectoryToDirectory(sourceDirectory, destinationDirectory);
-        } catch (Exception ex) {
-            log.error(String.format("Unable to copy directory: %s to %s", sourceDirectory, destinationDirectory), ex);
-        }
+    public static void copyDirectoryToDirectory(File sourceDirectory,
+                                                File destinationDirectory) throws IOException{
+        FileUtils.copyDirectoryToDirectory(sourceDirectory, destinationDirectory);
     }
 
     public static String readFileContents(File file) {
@@ -215,14 +212,9 @@ public class ImportFileUtil {
 
     }
 
-    public static void deleteDirectory(File deleteDir) {
-        try {
-            if (deleteDir.exists() && deleteDir.isDirectory()) {
-                FileUtils.deleteDirectory(deleteDir);
-                deleteDir.delete();
-            }
-        } catch (Exception ex) {
-            log.error(String.format("Unable to delete directory: %s", deleteDir.toString()), ex);
+    public static void deleteDirectory(File deleteDir) throws IOException{
+        if (deleteDir.exists() && deleteDir.isDirectory()) {
+            FileUtils.deleteDirectory(deleteDir);
         }
     }
 

--- a/src/main/java/org/opentestsystem/ap/itemimport/util/ImportHandlerUtil.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/util/ImportHandlerUtil.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.ap.itemimport.util;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.opentestsystem.ap.common.itembank.ItemManager;
 import org.opentestsystem.ap.common.model.ItemConstants;
@@ -49,24 +50,29 @@ public class ImportHandlerUtil {
                                      String wordListFullPath,
                                      String sourceItemFullPath,
                                      Path destinationPath) {
+        File tempZipDir = destinationPath.resolve("tempZip").toFile();
+        if (tempZipDir.mkdirs()) {
+            // Copy main item source directory to tempZip directory
+            File sourceDir = new File(sourceItemFullPath);
+            ImportFileUtil.copyDirectoryToDirectory(sourceDir, tempZipDir);
 
-        File sourceDir = new File(sourceItemFullPath);
-        // Temporarily copy Wordlist directory to source directory
-        if (StringUtils.isNotBlank(appProps.getWordlistId())) {
-            File wordlistDir = new File(wordListFullPath);
-            if (wordlistDir.exists() && sourceDir.exists()) {
-                ImportFileUtil.copyDirectoryToDirectory(wordlistDir, sourceDir);
+            // Copy Wordlist directory to tempZip directory
+            if (StringUtils.isNotBlank(appProps.getWordlistId())) {
+                File wordlistDir = new File(wordListFullPath);
+                if (wordlistDir.exists() && sourceDir.exists()) {
+                    ImportFileUtil.copyDirectoryToDirectory(wordlistDir, tempZipDir);
+                }
             }
-        }
 
-        // Create a Zip file containing all source files
-        ImportFileUtil.zipDirectory(sourceItemFullPath,
-                destinationPath.toString(),
-                ImportFileUtil.IMPORT_ZIP_FILENAME);
+            // Create a Zip file containing all source files
+            ImportFileUtil.zipDirectory(tempZipDir.toString(),
+                    destinationPath.toString(),
+                    ImportFileUtil.IMPORT_ZIP_FILENAME);
 
-        // Remove Wordlist directory from source directory
-        if (StringUtils.isNotBlank(appProps.getWordlistId()) && sourceDir.exists()) {
-            ImportFileUtil.deleteDirectory(sourceDir.toPath().resolve(appProps.getWordlistId()).toFile());
+            // Remove tempZip directory
+            if (tempZipDir.exists()) {
+                ImportFileUtil.deleteDirectory(tempZipDir);
+            }
         }
     }
 

--- a/src/main/java/org/opentestsystem/ap/itemimport/util/ImportHandlerUtil.java
+++ b/src/main/java/org/opentestsystem/ap/itemimport/util/ImportHandlerUtil.java
@@ -12,6 +12,7 @@ import org.opentestsystem.ap.itemimport.model.report.ImportResult;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +50,7 @@ public class ImportHandlerUtil {
     public static void createImportZipFile(ItemProps appProps,
                                      String wordListFullPath,
                                      String sourceItemFullPath,
-                                     Path destinationPath) {
+                                     Path destinationPath) throws IOException  {
         File tempZipDir = destinationPath.resolve("tempZip").toFile();
         if (tempZipDir.mkdirs()) {
             // Copy main item source directory to tempZip directory

--- a/src/main/resources/report_templates/import-report.ftl
+++ b/src/main/resources/report_templates/import-report.ftl
@@ -2,6 +2,7 @@
 ==================================================
 Import Report Summary
 ==================================================
+Import Id File: ${report.appProps.importIdFile}
     Is Dry Run: ${report.appProps.dryRun?c}
    Environment: ${report.appProps.environment}
     Start Time: ${report.startTime?datetime}


### PR DESCRIPTION
While running the import app in Smarter Balanced AWS environments a permission denied error occurred while creating the import.zip file. Previously the import.zip file was created on the items source directory. Now the items (and glossary if applicable) are both copied to a temporary directory where they are zipped and then the temporary directory is deleted